### PR TITLE
Corrections and change to hyperlink on BYS/ATO Page

### DIFF
--- a/pages/before-you-ship.md
+++ b/pages/before-you-ship.md
@@ -3,6 +3,6 @@ permalink: /lifecycle-of-a-project/before-you-ship/
 title: Before You Ship & ATO
 parent: Lifecycle of a Project
 ---
-An Authority to Operate (ATO) is a complicated security review process that **you must start AND complete** before you can deploy anything on the public web. Learn more about it in the [ATO section of the Before You Ship guide](https://pages.18f.gov/before-you-ship/ato/). You should review this documentation as soon as you start a project. You can ask for help in [#compliance-toolkit](https://18f.slack.com/archives/compliance-toolkit).
+An Authority to Operate (ATO) is a risk management process that **you must start and complete** before you can deploy a production system publicly on the web. Learn more about it in the [ATO section of the Before You Ship guide](https://pages.18f.gov/before-you-ship/). You should review this documentation as soon as you _start_ a project. You can ask for help in [#compliance-toolkit](https://18f.slack.com/archives/compliance-toolkit).
 
-Despite the “Before You Ship” name, everything in [18F's Before You Ship guide](https://pages.18f.gov/before-you-ship/) should be considered early and often. This guide is especially helpful when you’re starting to consider a project launch or feature release. This is not solely a last-minute, pre-launch checklist. If you have questions, the guide lists pertinent slack channels.
+Despite the “Before You Ship” name, everything in [18F's Before You Ship guide](https://pages.18f.gov/before-you-ship/) should be considered early and often. This guide is especially helpful when you’re starting to consider a project launch or feature release. This is not solely a last-minute, pre-launch checklist. If you have questions, the guide lists pertinent Slack channels.


### PR DESCRIPTION
Small corrections, but most importantly, we should not link to the inside of the BYS guide. The info architecture of that guide is changing rapidly, and that will lead to potential confusion.
