### PR TITLE
incorporate project lifecycle information from Before You Ship

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ _site/
 .sass-cache/
 .DS_store
 .*.swp
+.bundle/
 .jekyll*

--- a/pages/budeting.md
+++ b/pages/budeting.md
@@ -21,9 +21,11 @@ Below are some of the most important things to estimate at the start of the proj
 
 Typically, the biggest component of the budget will be labor hours. This is best estimated by asking subject matter experts to help estimate hours. For instance, asking a frontend engineer in [#eng-facilitators](https://18f.slack.com/messages/eng-facilitators/) to help estimate the time required for the known project interface could be helpful. This typically occurs during the [tech eval phase]({{ site.baseurl }}/lifecycle-of-a-project/tech-eval/) of the intake process, or alternatively you could ask group leads for estimates. Be sure to ping each resource you’ll potentially need on the project. Consider backend, frontend engineering, design, content, and product management staff during your estimation, all of whom have an appropriate slack channel for this kind of discussion.
 
+Will your team need to work more than 40 hours in a week, e.g. to support a launch? You should start the [comp time approvals process](https://handbook.18f.gov/benefits/#overtime-and-comp-time-policy) before that happens. We take this seriously.
+
 **Travel costs**
 
-Often your team will need to travel to the partner site for specific project milestones or activities. These might include design sprints, UX research and interviews, presentations of findings to stakeholders, project launches, post-launch celebrations, or debriefing. There may also be other ad-hoc travel required by various team members depending on project specifics. For example, many project teams find an in-person kick off to be very beneficial, as it allows for focused, face-to-face time for foundational exercises like backlog creation or story-mapping. 
+Often your team will need to travel to the partner site for specific project milestones or activities. These might include design sprints, UX research and interviews, presentations of findings to stakeholders, project launches, post-launch celebrations, or debriefing. There may also be other ad-hoc travel required by various team members depending on project specifics. For example, many project teams find an in-person kick off to be very beneficial, as it allows for focused, face-to-face time for foundational exercises like backlog creation or story-mapping.
 
 Be sure to address expectations for travel with the potential agency partner up front. This will not only allow you to budget more accurately, but will also give you an opportunity to gauge their reception to the 18F remote work policy. Identifying and addressing any reticence about this early on is vital for a strong working relationship.
 
@@ -43,7 +45,7 @@ This is an important but often overlooked component of the budget. Infrastructur
 
 **Miscellaneous**
 
-Does the project require any other specialized resources that aren’t covered by 18F? Printing needs? Legal counsel? 
+Does the project require any other specialized resources that aren’t covered by 18F? Printing needs? Legal counsel?
 
 ###How to estimate
 **Tech eval**
@@ -69,7 +71,7 @@ If you’re lost, there are many resources available on Slack to help. [#product
 You should also know that 18F does have rate changes, which requires additional sensitivity and partner management. You can always ask about impending rate changes in [#finance](https://18f.slack.com/messages/finance/). These can often throw a serious wrench in the budget building process, as can billing inaccuracies and unexpected infrastructure costs. Account for everything that you can, but you should plan for and expect to have missed some things. If you can cushion your budget for this, it will be to your benefit and will help you keep your project within its budget.
 
 ###More resources
-[How We Bill](https://docs.google.com/document/d/1Vm_gvwfxJVTLtM0-al62-o6dBySjQKI0zQkSvGfii6w/edit) 
+[How We Bill](https://docs.google.com/document/d/1Vm_gvwfxJVTLtM0-al62-o6dBySjQKI0zQkSvGfii6w/edit)
 
 [How much do you charge per hour?](https://docs.google.com/document/d/1Ou6pKGReuuE0HhujURRnhiosgfDonKY3sSiDlM_jnqo/edit)
 

--- a/pages/design-and-development.md
+++ b/pages/design-and-development.md
@@ -4,15 +4,15 @@ title: Design and development
 parent: Lifecycle of a Project
 ---
 
-###Web Design Standards 
-When developing new products, we work to use and reuse defined standards. One pioneering example of government-wide design standards is the alpha release of the draft [U.S. Web Design Standards](https://playbook.cio.gov/designstandards/) penned by 18F and USDS. The goal of the design standards is to create a more unified and holistic experience to visitors across government sites, provide examples and guidance on best practices in interaction patterns and accessibility, and to allow product teams to stand-up prototypes and websites more quickly. While they’re not a requirement, if an agency doesn’t already have an established style guide, the draft U.S. Web Design Standards can help save time, money, and effort. If you see something that needs to be updated, file an issue on [GitHub](https://github.com/18F/web-design-standards). If you have questions, ping the team in [#web-design-standards](https://18f.slack.com/messages/web-design-standards/). 
+###Web Design Standards
+When developing new products, we work to use and reuse defined standards. One pioneering example of government-wide design standards is the alpha release of the draft [U.S. Web Design Standards](https://playbook.cio.gov/designstandards/) penned by 18F and USDS. The goal of the design standards is to create a more unified and holistic experience to visitors across government sites, provide examples and guidance on best practices in interaction patterns and accessibility, and to allow product teams to stand-up prototypes and websites more quickly. While they’re not a requirement, if an agency doesn’t already have an established style guide, the draft U.S. Web Design Standards can help save time, money, and effort. If you see something that needs to be updated, file an issue on [GitHub](https://github.com/18F/web-design-standards). If you have questions, ping the team in [#web-design-standards](https://18f.slack.com/messages/web-design-standards/).
 
 ###Accessibility and 508 standards
 As government technologists, we must do everything within our power to serve all of our constituencies, regardless of ability. As part of that goal, we must offer accessible digital content and products that follow the government’s [508 standards](http://www.access-board.gov/guidelines-and-standards/communications-and-it/about-the-section-508-standards) for accessibility. In order to meet these standards, we follow the [WCAG 2.0 AA guidelines](http://www.w3.org/TR/WCAG20/). Accessibility standards should be incorporated early and often in a project to ensure a usable, compliant product. Before a product launch, please make sure to review [the 18F 508 checklist](https://pages.18f.gov/accessibility/checklist).
 
-Accessibility standards help our audience make sure they can use our digital properties, from people who use screen readers to those with color blindness. Following these standards also helps us write code that is cleaner, more organized, faster-loading, and more search engine-friendly. 
+Accessibility standards help our audience make sure they can use our digital properties, from people who use screen readers to those with color blindness. Following these standards also helps us write code that is cleaner, more organized, faster-loading, and more search engine-friendly.
 
-18F’s own Nick Bristow is an expert in this area and can offer guidance if you find problems that your team can’t tackle. You can also read through our [Accessibility Guide](https://pages.18f.gov/accessibility/) or get guidance from the Accessibility Guild in [#g-accessibility](https://18f.slack.com/messages/g-accessibility/). The goal of the Accessibility Guild is to help us develop good, accessible products from the start of production in order to provide an excellent user experience for everyone. 
+18F’s own Nick Bristow is an expert in this area and can offer guidance if you find problems that your team can’t tackle. You can also read through our [Accessibility Guide](https://pages.18f.gov/accessibility/) or get guidance from the Accessibility Guild in [#g-accessibility](https://18f.slack.com/messages/g-accessibility/). The goal of the Accessibility Guild is to help us develop good, accessible products from the start of production in order to provide an excellent user experience for everyone.
 
 ###Design Method Cards
 18F’s design team has prepared a pool of tools to help work with clients on agile product development called the [Design Method Cards](https://methods.18f.gov/). These tools offer ways for teams to collaborate with stakeholders on [Discovering](https://methods.18f.gov/discover/), [Deciding](https://methods.18f.gov/decide/), [Making](https://methods.18f.gov/make/), and [Validating](https://methods.18f.gov/validate/) designs, products, and research. They’re produced with agile product development in government in mind, so there are lots of great tips and information about the Paperwork Reduction Act, privacy, and other challenges.
@@ -25,7 +25,7 @@ The tools are available as physical cards (ask the Director of Design if there�
 
 If you have questions or suggestions, head over to [#design-methods](https://18f.slack.com/messages/design-methods/).
 
-###Open source 
+###Open source
 One of 18F’s founding principles is to take advantage of open source software development. Open source software facilitates cross-agency and industry sharing, provides extraordinary cost savings, and increases our impact. We always default to open source because:
 
 **Transparency leads to trust.**
@@ -60,4 +60,10 @@ Use the [18F Content Guide](https://pages.18f.gov/content-guide/) as you create 
 ###Product testing
 Part of the agile process is testing the products we build after every sprint demo, taking that feedback, and iteratively improving. Along with that constant iterative testing and feedback loop, we encourage thorough automated testing as an integrated development practice to catch bugs and errors early. This improves the stability of our applications and enables end-of-sprint manual testing to focus on improving the customer experience of everything we build.
 
-18F has extensive documentation for a [Testing Cookbook](https://pages.18f.gov/testing-cookbook/), [Automated Testing Resources](https://pages.18f.gov/automated-testing-playbook/), and soon, we’ll have an 18F/OCSIT Mobile Device Testing Library in the D.C. GSA office (for more hands-on device testing). The [#wg-testing group](https://18f.slack.com/messages/wg-testing/) can also help you. The testing working group aims to ensure the long-term success of 18F development projects by cultivating the best automated testing tools, practices, and training materials.  
+18F has extensive documentation for a [Testing Cookbook](https://pages.18f.gov/testing-cookbook/), [Automated Testing Resources](https://pages.18f.gov/automated-testing-playbook/), and soon, we’ll have an 18F/OCSIT Mobile Device Testing Library in the D.C. GSA office (for more hands-on device testing). The [#wg-testing group](https://18f.slack.com/messages/wg-testing/) can also help you. The testing working group aims to ensure the long-term success of 18F development projects by cultivating the best automated testing tools, practices, and training materials.
+
+#### Launch
+
+Exactly how big of a splashy launch are you planning? Is POTUS announcing it? Have you decided on the level of spikes in traffic your budget supports? You should coordinate this with your engineers, client, and the Infrastructure Team.
+
+We recommend that you start releasing the site to more and more users slowly in advance of any announcement. This will require planning with public affairs folks who want to help you avoid getting scooped, but it's also an incredibly important way to prevent last minute problems. Additionally, make sure at least one engineer is available to troubleshoot &mdash; somewhere with reliable internet &mdash; during an announcement (instead of, for example, on stage at the White House conference center).

--- a/pages/infrastructure.md
+++ b/pages/infrastructure.md
@@ -7,7 +7,7 @@ parent: Lifecycle of a Project
 
 Don’t underestimate the potential fallout of delivering a fragile service. There will be pressure to tackle other features, but you should focus on ensuring the high visibility and priority of infrastructure concerns. This way you can avoid scrambling to get your product’s infrastructure in shape when the launch deadline passes, the money runs out, etc. Consider having a separate backlog of just infrastructure stories, and throttling one into the top of the backlog sprint by sprint so they’re not ignored in favor of stakeholder- or user-driven stories that would otherwise drown them.
 
-You’re likely to have stakeholders who are not be able to articulate or understand infrastructure concerns as stories, let alone prioritize them, so someone on the team will need to act as their proxy. Take a look at the [list of suggested “good” production practices](https://pages.18f.gov/before-you-ship/infrastructure/good-production-practices/) to get an idea of the kinds of things the team should think about. (If you’re unclear on any of them yourself, you can ask questions in [#devops](https://18f.slack.com/messages/devops/).) Ensure your project backlog includes stories for the ones in bold at least, which are considered must-haves. 
+You’re likely to have stakeholders who are not be able to articulate or understand infrastructure concerns as stories, let alone prioritize them, so someone on the team will need to act as their proxy. Take a look at the [list of suggested “good” production practices](https://pages.18f.gov/before-you-ship/infrastructure/good-production-practices/) to get an idea of the kinds of things the team should think about. (If you’re unclear on any of them yourself, you can ask questions in [#devops](https://18f.slack.com/messages/devops/).) Ensure your project backlog includes stories for the ones in bold at least, which are considered must-haves.
 
 Analytics should also be on your mind early, both to help understand how users use your product as it develops, and how the speed and stability of your product affects their experience. See below for pointers on getting started with [DAP](http://www.digitalgov.gov/services/dap/) (for usage analytics) and [New Relic](http://newrelic.com/) (for application speed and subjective performance).
 
@@ -22,9 +22,19 @@ The cloud.gov team can offer [consulting](https://docs.cloud.gov/intro/terminolo
 
 ###Adopting DevOps practices
 
-If there’s a third pillar behind user-centered design and agile practices at 18F, it might be DevOps. “DevOps” refers to combining responsibility for a product’s operations into the activities of the development team. Applying DevOps early in development has a positive effect on minimizing risk and adopting good long-term architectural decisions. 
+If there’s a third pillar behind user-centered design and agile practices at 18F, it might be DevOps. “DevOps” refers to combining responsibility for a product’s operations into the activities of the development team. Applying DevOps early in development has a positive effect on minimizing risk and adopting good long-term architectural decisions.
 
 The use of cloud.gov for deployment practices makes many formerly operations-domain responsibilities practical to handle alongside normal development, so the barrier to adopting DevOps in a team at 18F is lower than elsewhere. That said, your team may be wholly unfamiliar with the Ops domain and reluctant to take on these responsibilities. In that case, consider having one person on the team focus on the infrastructure-focused stories early to get familiar with the tools available and get an initial deployment pipeline in version control, relying on help from [#devops](https://18f.slack.com/messages/devops/) or [#cloud-gov-support](https://18f.slack.com/messages/cloud-gov-support) as needed. Then emphasize pairing as new infrastructure stories are worked on to spread that skillset around the team.
+
+### Client expectations
+
+What will you do if something breaks? Have you talked to your client about their expectations of up time and their budget? 18F currently does not offer Service Level Agreements (SLAs), which normally include agreements about uptime and response time to downtime, but you should have an escalation protocol in place. Here is an example from the [betaFEC](https://beta.fec.gov) team.
+
+> 18F does not officially offer Service Level Agreements (SLAs), but we would still like to clarify expectations of up time for our client and users:
+>
+> Three main components are responsible for hosting [beta.fec.gov](https://beta.fec.gov) and its data: the betaFEC web app, cloud.gov, and api.data.gov. These services are all under constant monitoring and set up for low or zero-downtime deployments, and we expect them to operate continuously. Our data is updated nightly. Cloud.gov's current status and history of uptime is available [here](https://cloudgov.statuspage.io), and api.data.gov's is [here](https://synthetics.newrelic.com/report/UIoF9).
+>
+> Problems should be reported by opening an issue on [GitHub](https://github.com/18F/openfec). If you would like to escalate the issue, you can reach out to your 18F Product Manager by [texting/calling (555)555-5555/slack DMing/emailing/etc.]. We may not address issues outside of business hours until the next day.
 
 ###Planning for transition
 
@@ -37,11 +47,10 @@ Infrastructure work surrounding your product should result in repeatable deploym
 
 Treat this operations work as a development task rather than one-off efforts. This maximizes your team’s ability to retrace steps and share ownership as the makeup of your team inevitably changes over time.
 
-By using cloud.gov and capturing the full deployment process in your project’s repositories, you will also minimize the need for special access to AWS for those developing and maintaining your product. This will ease the work of future teams which may pick up your product after a big pause, and also makes it easier to transition ownership to your stakeholders when 18F’s work on the product ends. 
+By using cloud.gov and capturing the full deployment process in your project’s repositories, you will also minimize the need for special access to AWS for those developing and maintaining your product. This will ease the work of future teams which may pick up your product after a big pause, and also makes it easier to transition ownership to your stakeholders when 18F’s work on the product ends.
 
 ###Related groups and channels
 
 -   **cloud.gov** — If you have questions about the use of cloud.gov for your project’s infrastructure, ask in [#cloud-gov-business](https://18f.slack.com/messages/cloud-gov-business/). If your team needs help with using cloud.gov to implement one of your infrastructure stories, suggest they ask in [#cloud-gov-support](https://18f.slack.com/messages/cloud-gov-support).
 -   **Analytics** — The Analytics Guild’s mission is to integrate website analytics into all 18F projects. See our [Analytics Standards](https://github.com/18F/analytics-standards) for more information.
 -   **DevOps** — As described above, DevOps is less a group or skill so much as a practice. [#devops](https://18f.slack.com/messages/devops/) is a good place to discuss DevOps practices and approaches, as well as to get pointers on access to available tools which can address specific needs. For example, New Relic to measure subjective performance, Pingdom to measure and alert on availability, etc.
-

--- a/pages/project-communications.md
+++ b/pages/project-communications.md
@@ -5,7 +5,7 @@ parent: Lifecycle of a Project
 ---
 ###Developing a project comms plan
 
-The [distributed team]({{ site.baseurl }}/lifecycle-of-a-project/staffing/#distributed-teamwork) at 18F makes it crucial for communication plans to be established for every project early on — you won’t run into your teammates at the water cooler when they work across three time zones (check out this blog post to learn more about how 18F cultivates a [“remote first” mindset](https://18f.gsa.gov/2015/10/15/best-practices-for-distributed-teams/)). 
+The [distributed team]({{ site.baseurl }}/lifecycle-of-a-project/staffing/#distributed-teamwork) at 18F makes it crucial for communication plans to be established for every project early on — you won’t run into your teammates at the water cooler when they work across three time zones (check out this blog post to learn more about how 18F cultivates a [“remote first” mindset](https://18f.gsa.gov/2015/10/15/best-practices-for-distributed-teams/)).
 
 **Regular meetings**
 
@@ -21,19 +21,19 @@ Some tools you might use to facilitate regular meetings (like retros) include:
 
 **Partner communication and bug submission**
 
-We work with an empowered product owner, so a majority of the partner communication will (should) be with them, but stakeholders will likely be involved as well. Because of this, be sure to outline the process for bug submission (Trello? Waffle? Directly on a board vs other submission process?) and issue prioritization (Will this be done in sprint planning? Who has input?), as well as an escalation path for critical issues. As for frequency of communication, be proactive in general and start out high touch, then adjust to the needs of your team/partner as the project continues. 
+We work with an empowered product owner, so a majority of the partner communication will (should) be with them, but stakeholders will likely be involved as well. Because of this, be sure to outline the process for bug submission (Trello? Waffle? Directly on a board vs other submission process?) and issue prioritization (Will this be done in sprint planning? Who has input?), as well as an escalation path for critical issues. As for frequency of communication, be proactive in general and start out high touch, then adjust to the needs of your team/partner as the project continues.
 
 18F avoids long term maintenance contracts, so in all likelihood you’ll be handing off the product to another team to maintain. To that end, plan for the end of a project at the beginning (or at least closer to the beginning rather than at the end) in your documentation of how decisions came to be, architecture, and the technical requirements of your project. See the [Renewals and Handoffs]({{ site.baseurl }}/lifecycle-of-a-project/renewals-and-handoffs/) section for more on this.
 
 ###Filling out a communications plan
 
-As part of planning out your project communication, you need to fill out an [#outreach](https://18f.slack.com/messages/outreach/) team [Comms Plan form] (https://docs.google.com/document/d/1xc7H6m7lfesCN-phJGvGSDPmtoinB5sM9KAA8deMNTQ/edit) so that they can gather basic information about your product launch (this plan is used to do things like draft social media campaigns or help answer press questions). The [#outreach](https://18f.slack.com/messages/outreach/) team will then pass on the plan to GSA’s Office of Communications and Marketing and the Office of Congressional and Interagency Affairs. You can see samples of these comm plans [here](https://drive.google.com/drive/u/0/folders/0B7hjBcSbIxAnfndJTWJDWjVaX2NjVnRfNGhGazRjYnNVVXhHcnJuNmJOdEtXQ09VTkNBU0E). Here’s [a good example of a standard comms plan](https://docs.google.com/document/d/1hqdYs2yR4iBhqFP-utEcdqQLdteJvgx5lP9L2ROzNhI/edit#heading=h.luo7pdd2ubbk) and [one for a major launch](https://docs.google.com/document/d/1zFk9rpV8LcdbaaS25K1msRzGnEoi7i0QNR2vrcENatQ/edit#heading=h.luo7pdd2ubbk). 
+You need to designate a project “storyteller” who will give ongoing updates to the outreach team. This person does not have to be the product lead, and will serve as a conduit between the product and outreach team. Notify the outreach team of the storyteller contact in [#outreach](https://18f.slack.com/messages/outreach/).
 
-Additionally, you need to designate a project “storyteller” who will give ongoing updates to the outreach team. This person does not have to be the product lead, and will serve as a conduit between the product and outreach team. Notify the outreach team of the storyteller contact in [#outreach](https://18f.slack.com/messages/outreach/).
+The storyteller will fill out an [#outreach](https://18f.slack.com/messages/outreach/) team [Comms Plan form](https://docs.google.com/document/d/1xc7H6m7lfesCN-phJGvGSDPmtoinB5sM9KAA8deMNTQ/edit) so that they can gather basic information about your product launch (this plan is used to do things like draft social media campaigns or help answer press questions). The [#outreach](https://18f.slack.com/messages/outreach/) team will then pass on the plan to GSA’s Office of Communications and Marketing and the Office of Congressional and Interagency Affairs. You can see samples of these comm plans [here](https://drive.google.com/drive/u/0/folders/0B7hjBcSbIxAnfndJTWJDWjVaX2NjVnRfNGhGazRjYnNVVXhHcnJuNmJOdEtXQ09VTkNBU0E). Here’s [a good example of a standard comms plan](https://docs.google.com/document/d/1hqdYs2yR4iBhqFP-utEcdqQLdteJvgx5lP9L2ROzNhI/edit#heading=h.luo7pdd2ubbk) and [one for a major launch](https://docs.google.com/document/d/1zFk9rpV8LcdbaaS25K1msRzGnEoi7i0QNR2vrcENatQ/edit#heading=h.luo7pdd2ubbk).
 
 Every product must have:
 
-- About.yml entry
+- [An about.yml entry](#project-metadata)
 - A comms plan
 - Ideas for ~3 blog posts (from your team)
 
@@ -44,20 +44,28 @@ The outreach team will work with the storyteller to ensure that the above items 
 - Progress on comms plan / blog posts
 - Any other ways the outreach team can help your project
 - Upcoming speaking events / conferences that the project/product is represented at
-- Any updates that need to be conveyed to the agency partner’s outreach team (and who those people might be.)
-- Updates for 18F newsletter or Dolores or #news
-- Updates for open source community who might be able to help with ‘help-wanted’ tags
+- Any updates that need to be conveyed to or coordinated with the agency partner’s outreach team (and who those people might be), e.g. upcoming releases or blog posts
+- Updates for:
+    - The 18F newsletter
+    - Dolores
+    - #news
+    - The weekly all-hands
+- Updates for open source community who might be able to help with open `help-wanted` issues
+    - Outreach adds tasks that are requesting external support to 18F's biweekly external newsletter to give them an additional boost.
 
 In the first meeting with the storyteller, the outreach team will go over the blog mission and how we talk about our products. Future (very, very short) meetings will follow the template listed above.
 
-
 ###How to communicate before a project has shipped
 
-Work with your partner team to determine what kind of updates and reporting they need (and/or are expected to present to their stakeholders). This will determine the best way to communicate about the status with them — some may want to use a [dashboard](https://18f.gsa.gov/dashboard/) to serve this purpose (more information on this below), while others may use a [public wiki](https://github.com/18F/doi-extractives-data/wiki) or will be open to using a [public Trello board](https://18f.gsa.gov/2015/12/07/what-exactly-do-we-even-do-all-day/). Others may even request emailed reports or weekly updates on hours; however, we often negotiate to prevent this in our IAAs. Check with [#teamops]() if your client requests this. There is no one set method of reporting across projects. 
+Work with your partner team to determine what kind of updates and reporting they need (and/or are expected to present to their stakeholders). This will determine the best way to communicate about the status with them — some may want to use a [dashboard](https://18f.gsa.gov/dashboard/) to serve this purpose (more information on this below), while others may use a [public wiki](https://github.com/18F/doi-extractives-data/wiki) or will be open to using a [public Trello board](https://18f.gsa.gov/2015/12/07/what-exactly-do-we-even-do-all-day/). Others may even request emailed reports or weekly updates on hours; however, we often negotiate to prevent this in our IAAs. Check with [#teamops](https://18f.slack.com/messages/teamops) if your client requests this. There is no one set method of reporting across projects.
 
-The 18F [dashboard](https://18f.gsa.gov/dashboard/) provides agency stakeholders and the general public insight into what projects 18F is currently working on. Keeping the status of your project up to date also helps 18F plan staffing. Some of the updates to the dashboard are automatic via an about.yml file in project GitHub repos; others require manual updates. You can learn more about what how to maintain your page in [#dashboard](https://18f.slack.com/messages/dashboard).
+#### Project metadata
 
-As you finalize the first launch date of your product, be sure to add your launch date (or launch date range) to the [18F Events Google Calendar](https://calendar.google.com/calendar/embed?src=gsa.gov_3rapmucstu32ma18da84el20ug@group.calendar.google.com&ctz=America/New_York). In many cases, the launch of a product is usually in a wide range of dates and narrows as your team gets closer to launch, but we need to give our friends in [#outreach](https://18f.slack.com/messages/outreach/) at least an idea of this range as far in advance as we can for the sake of their workflow. So for example, if you know right now that a product was launching at some point in January, we’d make note of that on January 1 and reference the four-week timeframe it will likely launch in (rather than spanning the entire month of January and clogging up the calendar). You’ll want to adjust that timeframe as your launch date solidifies.
+The 18F [dashboard](https://18f.gsa.gov/dashboard/) provides agency stakeholders and the general public insight into what projects 18F is currently working on. The dashboard (and other things at 18F) are powered by putting an [about.yml](https://github.com/18F/about_yml) entry in your main project repository. The outreach team recommends creating this at the beginning of your project and updating it monthly. Keeping the status of your project up to date also helps 18F plan staffing. You can learn more about how to maintain your page in [#dashboard](https://18f.slack.com/messages/dashboard).
+
+#### Dates
+
+As early as possible, add your launch date (or launch date range) and project milestones to the [18F Events Google Calendar](https://calendar.google.com/calendar/embed?src=gsa.gov_3rapmucstu32ma18da84el20ug@group.calendar.google.com&ctz=America/New_York). This helps several teams, especially outreach. Rough estimates are welcome; you can always update the calendar as you go.
 
 ###How to communicate after a project has shipped
 
@@ -67,7 +75,7 @@ To ensure the best user experience possible, it’s important to proactively dev
 
 You can do this by anticipating user questions and issues and reviewing the project’s initial user research. Explain user stories that the product does not solve. Be sure to incorporate learnings from any UX inconsistencies that may have been revealed from testing as well (for example, if something was hard for beta users to find but has not yet been adjusted in the user flow, make sure the FAQ calls this out and links to it directly).
 
-Don’t forget to **give your users options for feedback**. And in creating FAQ pages and avenues for feedback, consider options for both the general public (forms or specific email addresses for questions) as well as developers (API documentation, a wiki for outlining the limitations of the data, what issues are a priority, etc). 
+Don’t forget to **give your users options for feedback**. And in creating FAQ pages and avenues for feedback, consider options for both the general public (forms or specific email addresses for questions) as well as developers (API documentation, a wiki for outlining the limitations of the data, what issues are a priority, etc).
 
 **Blog posts**
 
@@ -75,4 +83,4 @@ Don’t forget to **give your users options for feedback**. And in creating FAQ 
 
 ###Other resources
 
-You are not alone in creating a communications plan; the artifacts and exact processes might vary, but every project at 18F has had to address communication. Use your peers as resources: the [#outreach](https://18f.slack.com/messages/outreach/) team is always ready to help with official communications plans as well as less formal strategies. Other product leads will also have great insight to offer and can help you troubleshoot specific issues; ask for assistance or about their experiences in [#product](https://18f.slack.com/messages/product). 
+You are not alone in creating a communications plan; the artifacts and exact processes might vary, but every project at 18F has had to address communication. Use your peers as resources: the [#outreach](https://18f.slack.com/messages/outreach/) team is always ready to help with official communications plans as well as less formal strategies. Other product leads will also have great insight to offer and can help you troubleshoot specific issues; ask for assistance or about their experiences in [#product](https://18f.slack.com/messages/product).

--- a/pages/user-research.md
+++ b/pages/user-research.md
@@ -5,11 +5,11 @@ parent: Lifecycle of a Project
 ---
 ###Early planning and discovery
 
-As articulated in our [18F Partnership Playbook](https://pages.18f.gov/partnership-playbook/), we start every new engagement by taking a [fresh look at the problem](https://pages.18f.gov/partnership-playbook/3-problem-first/). We do this as a joint team with the client over the course of two to six weeks depending on the scope of the engagement. During this phase, which we call “Discovery”, the core product team interviews users and agency stakeholders to validate and more deeply understand the problem, desired goals and outcomes, and the organization’s priorities. This discovery phase is facilitated by a UX designer or researcher (who should be assigned to your team during the [intake staffing process]({{ site.baseurl }}/lifecycle-of-a-project/staffing/) and should include observation and participation by the entire team, including you, designers, developers, and the product owner on the partner side. 
+As articulated in our [18F Partnership Playbook](https://pages.18f.gov/partnership-playbook/), we start every new engagement by taking a [fresh look at the problem](https://pages.18f.gov/partnership-playbook/3-problem-first/). We do this as a joint team with the client over the course of two to six weeks depending on the scope of the engagement. During this phase, which we call “Discovery”, the core product team interviews users and agency stakeholders to validate and more deeply understand the problem, desired goals and outcomes, and the organization’s priorities. This discovery phase is facilitated by a UX designer or researcher (who should be assigned to your team during the [intake staffing process]({{ site.baseurl }}/lifecycle-of-a-project/staffing/) and should include observation and participation by the entire team, including you, designers, developers, and the product owner on the partner side.
 
-If a partner has already conducted some research before engaging with 18F, you’ll want to gather any raw and synthesized research materials they can provide. More often the partner agency will not have conducted user research, so that will be one of the first things you’ll need to do. Either way, we conduct a discovery phase so we can be sure that we thoroughly understand the problem as well as validate any initial research or assumptions our partner may have. 
+If a partner has already conducted some research before engaging with 18F, you’ll want to gather any raw and synthesized research materials they can provide. More often the partner agency will not have conducted user research, so that will be one of the first things you’ll need to do. Either way, we conduct a discovery phase so we can be sure that we thoroughly understand the problem as well as validate any initial research or assumptions our partner may have.
 
-The partnership playbook, intake process, and IAA conversations should make the discovery phase clear to our partners. However, you and the UX designer or researcher will likely need to advocate for this phase (and solicit users to talk to) as early as possible to make sure it gets carried out. Some of our partners may come to the table with their assumptions fairly set, but it’s important to advocate for a thorough round of discovery. 
+The partnership playbook, intake process, and IAA conversations should make the discovery phase clear to our partners. However, you and the UX designer or researcher will likely need to advocate for this phase (and solicit users to talk to) as early as possible to make sure it gets carried out. Some of our partners may come to the table with their assumptions fairly set, but it’s important to advocate for a thorough round of discovery.
 
 Additionally, while the partner’s problems and goals will be broadly and roughly defined through the intake and IAA process, the discovery phase should still be used to validate them, reveal other goals or problems that may need to be pursued, and narrow in on the top priorities.
 
@@ -17,7 +17,7 @@ Additionally, while the partner’s problems and goals will be broadly and rough
 
 The discovery research phase will usually involve identifying and recruiting users to speak to. This is facilitated by a UX designer or researcher, but we can and should rely heavily on our partner to connect us to potential users, as we make clear in our [18F Partnership Playbook](https://pages.18f.gov/partnership-playbook/). Other [information-gathering exercises](https://methods.18f.gov/discover/) may also be used to study our partner’s problem space, and learn more deeply about user behavior and motivations. This work can help the team focus in on the highest priority users and problems and come up with potential solutions that can then be broken down into user stories.
 
-There are a few ways to leverage this research to come up with some general hypotheses and user stories, or epics. Creating a [problem statement](https://pages.18f.gov/lean-product-design/2-problem-statement/) is a great way to frame (or reframe) the problem, and can help kick off the process of mapping problems to hypotheses, and the metrics you will use to test them. Clearly [articulating the goals and outcomes of your project and mapping them to a target audience](https://pages.18f.gov/agile/1-goal.html) can also help you create milestones you can use to plan your roadmap. 
+There are a few ways to leverage this research to come up with some general hypotheses and user stories, or epics. Creating a [problem statement](https://pages.18f.gov/lean-product-design/2-problem-statement/) is a great way to frame (or reframe) the problem, and can help kick off the process of mapping problems to hypotheses, and the metrics you will use to test them. Clearly [articulating the goals and outcomes of your project and mapping them to a target audience](https://pages.18f.gov/agile/1-goal.html) can also help you create milestones you can use to plan your roadmap.
 
 Depending on the project, there are a variety of other potential deliverables or artifacts that may come out of the discovery phase (as well as later phases). Some examples include:
 
@@ -27,7 +27,7 @@ Depending on the project, there are a variety of other potential deliverables or
 -   Research plan [[example](https://docs.google.com/document/d/1vAc5k2yubu2MN2rFc3liiOm5F0D-fo3AkPm0YU-u8l8/edit)] [[example](https://docs.google.com/a/gsa.gov/document/d/19Dw2VnLgW9CKK6z8WoGhZ8qzXyiV9Wp96doDtg1I2qE/edit?usp=sharing)]
 -   Prototypes
 -   Ecosystem map [[external example](http://www.uxbooth.com/articles/designing-digital-strategies-part-1-cartography/)]
--   Personas 
+-   Personas
 -   Design and/or experience principles [[18F Guide](https://pages.18f.gov/design-principles-guide/)]
 -   Opportunity map
 
@@ -39,12 +39,8 @@ It can be difficult to find people to talk to the government about their experie
 
 ###User research in the [Build, Measure, Learn Cycle](https://pages.18f.gov/lean-product-design/)
 
-Set a regular cadence for gathering ongoing feedback, so that you can have it on everyone’s schedule, and so that you can work feedback into your plan on a regular basis. We suggest the entire team observe the feedback at least every six weeks, but depending on the specifics of your project, you might want this to happen more frequently, or at certain intervals that match up to significant milestones. You will know as you plan, when you expect to have released enough of some testable component of work so that it makes sense to get feedback. 
+Set a regular cadence for gathering ongoing feedback, before and after launch, so that you can have it on everyone’s schedule, and so that you can work feedback into your plan on a regular basis. We suggest the entire team observe the feedback at least every six weeks, but depending on the specifics of your project, you might want this to happen more frequently, or at certain intervals that match up to significant milestones. You will know as you plan, when you expect to have released enough of some testable component of work so that it makes sense to get feedback.
 
 ###Getting research support
 
 If your project has gone through intake, there should be design staff assigned to your team who will help define the work that needs to be done, conduct the research, and present the results. If design staff are not assigned to your team immediately, follow up with the intake team in [#project-intake](https://18f.slack.com/archives/project-intake). Remember that projects that require an IAA will only be staffed after the IAA is signed. They will usually need guidance from product in terms of the scope of the research and the overall business goals, but they’re the experts in user research, and their expertise should be leveraged as much as possible. For general research assistance, you can always drop a comment describing your need in the [#research](https://18f.slack.com/messages/research/) guild. Additional design staff must be approved by the design director prior to beginning work.
-
-
-
-


### PR DESCRIPTION
Corresponds to https://github.com/18F/before-you-ship/pull/151. This merges in information that previously existed in Before You Ship, including the changes @melodykramer proposed in https://github.com/18F/before-you-ship/pull/149.

The diff is a bit messy because my editor automatically removes any trailing whitespace when I edit a file—sorry to make it harder to follow!
