### PR TITLE
Updates docker compose volume to product-guide

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,4 +5,4 @@ services:
     ports:
       - "4000:4000"
     volumes:
-      - .:/handbook
+      - .:/product-guide


### PR DESCRIPTION
I had trouble running this repo locally (exited: `Could not locate Gemfile or .bundle/ directory`).

This PR changes the `docker-compose.yml` settings to target the `product-guide` volume.