### PR TITLE
Fix typo in navigation & hopefully fix footer link to repo

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,7 +22,7 @@ sass:
 github_info:
   organization: 18F
   repository: product-guide
-  default_branch: master
+  default_branch: 18f-pages
 
 search_site_handle: product-guide.18f.gov
 

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -9,7 +9,7 @@ primary:
         href: /discover/audience/
       - text: Understand the 'as-is' process
         href: /discover/process/
-      - text: Undertsand the technical landscape
+      - text: Understand the technical landscape
         href: /discover/technical/
       - text: Understand the regulatory landscape
         href: /discover/compliance/


### PR DESCRIPTION
I saw a typo in the navigation for this guide ("Undertsand the technical landscape"), and when I clicked "Edit this page" to try to correct the typo, I got a 404 link. These changes should hopefully fix both of those problems, if I've understood how the configuration works.