### PR TITLE
Update index.md to add section on requesting non-public information

### DIFF
--- a/index.md
+++ b/index.md
@@ -15,4 +15,4 @@ As a product manager at 18F, you may be put in a client-facing role to help a go
 
 ## Accessing Information in this Guide
 
-If you see a resource linked in this guide that is not public that you’d potentially be interested in, let us know by [opening an issue on the GitHub repo for this site](https://github.com/18F/product-guide/issues).
+If you see a resource linked in this guide that is not public that you’d potentially be interested in, let us know by [opening an issue on the GitHub repo for this site](https://github.com/18F/product-guide/issues). Not all assets linked in this guide may be suitable for public release, but we can review requests for materials to determine what is suitable.

--- a/index.md
+++ b/index.md
@@ -12,3 +12,7 @@ This guide is for people at 18F who are wondering what to expect from a product 
 As a product manager at 18F, you may be put in a client-facing role to help a government partner build a mission critical product.  You may also be working on one of TTS’s flagship products, like <a href="https://eregs.github.io/" target="_blank">eRegs</a>, <a href="https://federalist.18f.gov" target="new">Federalist</a>, <a href="https://cloud.gov" target="new">cloud.gov</a> or <a href="https://login.gov/" target="_blank">login.gov</a>. In all cases, you will create or steward the product vision and strategy, and drive a cross-functional team to deliver the right product to the right audience. We will talk more about this in the [Defining the future state]({{site.baseurl}}/define/) section.
 
 **You will also focus on sustainability.** Anything we build should empower our partner agencies to better meet their mission, be relatively easy for them to adopt and support, and be easy for end users to use. If we are building something with a partner, the product needs to be constructed and hosted in a way that the partner can manage, and the partner should be empowered to take over after we leave. We'll talk more about this in the [Enable partners for long-term success]({{site.baseurl}}/partners/) section.
+
+## Accessing Information in this Guide
+
+If you see a resource linked in this guide that is not public that you’d potentially be interested in, let us know by [opening an issue on the GitHub repo for this site](https://github.com/18F/product-guide/issues).


### PR DESCRIPTION
Add section for requesting information that is not available publicly, but that is linked to on various pages in the guide.

There are a number of assets linked to and referred to in this guide that are on the TTS Google Drive, and not available publicly. It might be helpful for viewers outside of 18F/TTS (who may be at other Federal agencies) to be able to ask if certain assets currently on Google Drive can be reviewed for possible public release. Identifying assets that are not currently publicly, that might be possible to share with those outside of TTS could significantly increase the value of this guide for helping other agencies.

This would also be consistent with the [18F Open Source policy](https://18f.gsa.gov/open-source-policy/):
> The default position of 18F when developing new projects is to...Develop our work in the open... Publish publicly all source code created or modified by 18F, whether developed in-house by government staff or through contracts negotiated by 18F.
