### PR TITLE
Update footer to match other guides

### DIFF
--- a/_data/usa_identifier.yaml
+++ b/_data/usa_identifier.yaml
@@ -1,32 +1,31 @@
 # Identifier data
 
-identifier_data:
-  - site_name: 18F Product Guide
-    site_email: 18F@gsa.gov
-    site_url: https://product-guide.18f.gov
-    site_about: https://product-guide.18f.gov
-    agency: U.S. General Services Administration
-    agency_acronym: GSA
-    agency_logo: gsa-logo-blue.svg
-    agency_url: https://www.gsa.gov
-    agency_about_url: https://www.gsa.gov/about
-    org_primary: Technology Transformation Services
-    org_primary_acronym: TTS
-    org_primary_url: https://www.gsa.gov/tts/
-    org_primary_email: tts-info@gsa.gov
-    org_primary_about: https://www.gsa.gov/tts/
-    org_primary_bio: "As part of GSA’s Technology Transformation Services (TTS), we apply modern methodologies and technologies to improve the public’s experience with government. We help agencies make their services more accessible, efficient, and effective with modern applications, platforms, processes, personnel, and software solutions."
-    org_secondary: 18F
-    org_secondary_acronym: 18F
-    org_secondary_logo: 18f-logo-blue.svg
-    org_secondary_url: https://18f.gsa.gov
-    org_secondary_email: 18F@gsa.gov
-    org_secondary_about: https://18f.gsa.gov/about/
-    org_secondary_bio: "TTS Solutions is a portfolio of products and services that help agencies improve delivery of information and services to the public."
-    foia_request_url: "https://www.gsa.gov/reference/freedom-of-information-act-foia"
-    fraud_waste_abuse_url: "https://www.gsaig.gov/"
-    no_fear_act_url: "https://www.gsa.gov/about-us/organization/office-of-civil-rights/notification-and-federal-employee-antidiscrimination-and-retaliation-act-of-2002"
-    budget_performance_url: "https://www.gsa.gov/reference/reports/budget-performance"
-    accessibility_url: "https://www.gsa.gov/website-information/accessibility-aids"
-    usagov_contact_url: "https://www.usa.gov/contact"
-    privacy_policy-url: https://www.gsa.gov/website-information/website-policies
+site_name: 18F Product Guide
+site_email: 18F@gsa.gov
+site_url: https://product-guide.18f.gov
+site_about: https://product-guide.18f.gov
+agency: U.S. General Services Administration
+agency_acronym: GSA
+agency_logo: gsa-logo-blue.svg
+agency_url: https://www.gsa.gov
+agency_about_url: https://www.gsa.gov/about
+org_primary: Technology Transformation Services
+org_primary_acronym: TTS
+org_primary_url: https://www.gsa.gov/tts/
+org_primary_email: tts-info@gsa.gov
+org_primary_about: https://www.gsa.gov/tts/
+org_primary_bio: "As part of GSA’s Technology Transformation Services (TTS), we apply modern methodologies and technologies to improve the public’s experience with government. We help agencies make their services more accessible, efficient, and effective with modern applications, platforms, processes, personnel, and software solutions."
+org_secondary: 18F
+org_secondary_acronym: 18F
+org_secondary_logo: 18f-logo-blue.svg
+org_secondary_url: https://18f.gsa.gov
+org_secondary_email: 18F@gsa.gov
+org_secondary_about: https://18f.gsa.gov/about/
+org_secondary_bio: "TTS Solutions is a portfolio of products and services that help agencies improve delivery of information and services to the public."
+foia_request_url: "https://www.gsa.gov/reference/freedom-of-information-act-foia"
+fraud_waste_abuse_url: "https://www.gsaig.gov/"
+no_fear_act_url: "https://www.gsa.gov/about-us/organization/office-of-civil-rights/notification-and-federal-employee-antidiscrimination-and-retaliation-act-of-2002"
+budget_performance_url: "https://www.gsa.gov/reference/reports/budget-performance"
+accessibility_url: "https://www.gsa.gov/website-information/accessibility-aids"
+usagov_contact_url: "https://www.usa.gov/contact"
+privacy_policy_url: https://www.gsa.gov/website-information/website-policies

--- a/_includes/components/usa_identifier.html
+++ b/_includes/components/usa_identifier.html
@@ -1,0 +1,68 @@
+{% assign identifier = site.data.usa_identifier %}
+<div class="usa-identifier">
+  <section class="usa-identifier__section usa-identifier__section--masthead" aria-label="Agency identifier">
+    <div class="usa-identifier__container">
+      <div class="usa-identifier__logos">
+        <a href="https://www.gsa.gov/" class="usa-identifier__logo">
+          <img class="usa-identifier__logo-img" src="{{ site.baseurl }}/images/{{ identifier.agency_logo }}" alt="GSA logo" role="img" />
+        </a>
+      </div>
+      <div class="usa-identifier__identity text-base-lightest" aria-label="Agency description">
+        <p class="usa-identifier__identity-domain">{{ identifier.site_name }}</p>
+        <p class="usa-identifier__identity-disclaimer text-base-lightest">An official website of the
+          <a href="https://www.gsa.gov/about-us/organization/federal-acquisition-service/technology-transformation-services">
+            GSA’s Technology Transformation Services
+          </a>
+        </p>
+      </div>
+    </div>
+  </section>
+    <nav class="usa-identifier__section usa-identifier__section--required-links" aria-label="Important links">
+      <div class="usa-identifier__container">
+        <ul class="usa-identifier__required-links-list">
+          <li class="usa-identifier__required-links-item">
+            <a class="usa-identifier__required-link usa-link" href="{{ identifier.agency_about_url }}" title="About GSA">
+              About GSA
+            </a>
+          </li>
+          <li class="usa-identifier__required-links-item">
+            <a class="usa-identifier__required-link usa-link" href="{{ identifier.accessibility_url }}" title="View accessibility statement">
+              Accessibility support
+            </a>
+          </li>
+          <li class="usa-identifier__required-links-item">
+            <a class="usa-identifier__required-link usa-link" href="{{ identifier.foia_request_url }}" title="Submit a Freedom of Information Act (FOIA) request">
+              FOIA requests
+            </a>
+          </li>
+          <li class="usa-identifier__required-links-item">
+            <a class="usa-identifier__required-link usa-link" href="{{ identifier.no_fear_act_url }}" title="View No FEAR Act data">
+              No FEAR Act data
+            </a>
+          </li>
+          <li class="usa-identifier__required-links-item">
+            <a class="usa-identifier__required-link usa-link" href="{{ identifier.fraud_waste_abuse_url }}" title="Office of the Inspector General">
+              Office of the Inspector General
+            </a>
+          </li>
+          <li class="usa-identifier__required-links-item">
+            <a class="usa-identifier__required-link usa-link" href="{{ identifier.budget_performance_url }}" title="View budget and performance reports">
+              Performance reports
+            </a>
+          </li>
+          <li class="usa-identifier__required-links-item">
+            <a class="usa-identifier__required-link usa-link" href="{{ identifier.privacy_policy_url }}" title="Our privacy policy">
+              Privacy policy
+            </a>
+          </li>
+        </ul>
+      </div>
+    </nav>
+  <section class="usa-identifier__section usa-identifier__section--usagov" aria-label="U.S. government information and services">
+    <div class="usa-identifier__container">
+      <div class="usa-identifier__usagov-description text-base-lightest">Looking for U.S. government information and services?</div>
+      <a href="https://www.usa.gov/" class="usa-link">Visit USA.gov</a>
+    </div>
+  </section>
+</div>
+

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,72 +1,23 @@
-{% assign identifier = site.data.usa_identifier.identifier_data[0] %}
-<div class="usa-identifier">
-  <section class="usa-identifier__section usa-identifier__section--masthead" aria-label="Agency identifier">
-    <div class="usa-identifier__container">
-      <div class="usa-identifier__logos">
-        <a href="https://www.gsa.gov/" class="usa-identifier__logo">
-          <img class="usa-identifier__logo-img" src="{{ site.baseurl }}/images/{{ identifier.agency_logo }}" alt="GSA logo" role="img" />
-        </a>
+{% assign identifier = site.data.usa_identifier %}
+<footer class="usa-footer" role="contentinfo">
+<div class="usa-footer__secondary-section">
+  <div class="grid-container">
+    <div class="grid-row grid-gap">
+      <div class="usa-footer__contact-links mobile-lg:grid-col-12">
+        <div class="usa-footer grid-row">
+          <div class="grid-col-auto">
+            This project is maintained by <a class="usa-link" href="https://18f.gsa.gov/">18F</a>
+          </div>
+        </div>
+        <div class="usa-footer grid-row">
+          <div class="grid-col-auto">
+            Have questions or would like to contact us? Email us at <a class="usa-link" href="mailto:{{ identifier.site_email }}">{{ identifier.site_email }}</a>
+          </div>
+        </div>
       </div>
-      <div class="usa-identifier__identity text-base-lightest" aria-label="Agency description">
-        <p class="usa-identifier__identity-domain">18F Product Guide</p>
-        <p class="usa-identifier__identity-disclaimer text-base-lightest">An official website of the
-          <a href="https://www.gsa.gov/about-us/organization/federal-acquisition-service/technology-transformation-services">
-            GSA’s Technology Transformation Services
-          </a>
-        </p>
-      </div>
     </div>
-  </section>
-  <nav class="usa-identifier__section usa-identifier__section--required-links" aria-label="Important links">
-    <div class="usa-identifier__container">
-      <ul class="usa-identifier__required-links-list">
-        <li class="usa-identifier__required-links-item">
-          <a class="usa-identifier__required-link usa-link" href="{{ identifier.agency_about_url }}" title="About GSA">
-            About GSA
-          </a>
-        </li>
-        <li class="usa-identifier__required-links-item">
-          <a class="usa-identifier__required-link usa-link" href="{{ identifier.accessibility_url }}" title="View accessibility statement">
-            Accessibility support
-          </a>
-        </li>
-        <li class="usa-identifier__required-links-item">
-          <a class="usa-identifier__required-link usa-link" href="https://18f.gsa.gov/contact/" title="Contact us">
-            Contact us
-          </a>
-        </li>        
-        <li class="usa-identifier__required-links-item">
-          <a class="usa-identifier__required-link usa-link" href="{{ identifier.foia_request_url }}" title="Submit a Freedom of Information Act (FOIA) request">
-            FOIA requests
-          </a>
-        </li>
-        <li class="usa-identifier__required-links-item">
-          <a class="usa-identifier__required-link usa-link" href="{{ identifier.no_fear_act_url }}" title="View No FEAR Act data">
-            No FEAR Act data
-          </a>
-        </li> 
-        <li class="usa-identifier__required-links-item">
-          <a class="usa-identifier__required-link usa-link" href="{{ identifier.fraud_waste_abuse_url }}" title="Office of the Inspector General">
-            Office of the Inspector General
-          </a>
-        </li>                   
-        <li class="usa-identifier__required-links-item">
-          <a class="usa-identifier__required-link usa-link" href="{{ identifier.budget_performance_url }}" title="View budget and performance reports">
-            Performance reports
-          </a>
-        </li>
-        <li class="usa-identifier__required-links-item">
-          <a class="usa-identifier__required-link usa-link" href="{{ identifier.privacy_policy-url }}" title="Our privacy policy">
-            Privacy policy
-          </a>
-        </li>
-      </ul>
-    </div>
-  </nav>
-  <section class="usa-identifier__section usa-identifier__section--usagov" aria-label="U.S. government information and services">
-    <div class="usa-identifier__container">
-      <div class="usa-identifier__usagov-description text-base-lightest">Looking for U.S. government information and services?</div>
-      <a href="https://www.usa.gov/" class="usa-link">Visit USA.gov</a>
-    </div>
-  </section>
+  </div>
 </div>
+{% include components/usa_identifier.html %}
+</footer>
+


### PR DESCRIPTION
This PR updates the footer to match the format of the other 18F guides:
- Adding a footer section with an email address and link to the 18F page
- Removing contact-us from the identifier
 
 On the technical side also for consistency

- Moves identifier into it's own component file
- Flattens the identifier data in `identifier.yaml`
👓  [Preview](https://federalist-a9f64cd7-e403-4d17-bbda-59e512290555.app.cloud.gov/preview/18f/product-guide/ik_update-footer/)